### PR TITLE
Clarify configuration options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,77 @@ configuration is split into four sections:
   memory-efficient path.
 
 Refer to [`configs/example.yaml`](configs/example.yaml) for a complete list of
-available fields and their defaults.
+available fields and their defaults. The sections expand to the following
+parameters:
+
+### `general`
+
+- `debug` — increases logging verbosity when set to a truthy value.
+- `finetune_seed` — random seed forwarded to dataset shuffling and training.
+
+### `model`
+
+- `name` — Hugging Face model identifier or local path to load.
+- `use_lora` — enables LoRA adapters instead of full fine-tuning when `true`.
+- `lora_rank` — rank of the LoRA decomposition; higher increases adapter
+  capacity.
+- `pretrain` — starts from randomly initialised weights instead of a pretrained
+  checkpoint.
+- `cache_dir` — optional directory passed to the Hugging Face loaders for
+  storing downloaded weights.
+- `trust_remote_code` — allows loading custom model code when required.
+
+### `dataset`
+
+- `train_file` — path to the JSONL file containing training samples.
+- `eval_file` — path to the JSONL file containing evaluation samples.
+- `data_file` — alternative single JSONL file used when train and eval are
+  split dynamically.
+- `eval_split` — fraction of examples reserved for evaluation when using a
+  combined dataset file.
+- `split_seed` — seed controlling the deterministic split of combined datasets.
+- `max_items` — limits the number of examples loaded for quick experiments.
+- `max_length` — truncation length applied during tokenisation.
+- `predictors` — number of asynchronous dataloader worker processes.
+- `train_all` — toggles training on the full dataset without a validation split.
+- `plain` — forces the plain Hugging Face trainer without the JEPA loss.
+- `remove_thinking` — strips hidden reasoning tags from the dataset when `true`.
+- `cache_dir` — local cache directory for processed dataset artefacts.
+
+### `training`
+
+- `output_dir` — directory where checkpoints, logs, and metrics are stored.
+- `batch_size` — number of examples processed per device step.
+- `grad_accum` — gradient accumulation steps to simulate larger batches.
+- `learning_rate` — base learning rate for the optimiser.
+- `num_epochs` — maximum number of epochs to train.
+- `eval_steps` — interval (in optimiser steps) between evaluation runs.
+- `lbd` — JEPA representation loss weight.
+- `gamma` — JEPA predictor loss weight.
+- `last_token` — token index used when computing the JEPA objective (`-1`
+  selects the final token).
+- `regular` — disables the JEPA loss and runs a standard language modelling
+  objective when `true`.
+- `track_flop` — enables FLOP counting during training for benchmarking.
+- `additive_mask` — switches the attention mask computation to the additive
+  form; incompatible with memory-efficient mode.
+- `memory_efficient` — enables chunked attention to reduce peak VRAM usage.
+
+When training, we recommend enabling the memory-efficient path to reduce peak
+VRAM usage and maintain consistent results. The trade-offs are:
+
+⚖️ Trade-offs:
+Advantages:
+
+- 2-3x reduction in peak VRAM usage
+- Enables larger batch sizes and longer sequences
+- Identical training results
+- Easy to enable with single flag
+
+Disadvantages:
+
+- Slightly slower (3 forward passes vs 1 concatenated)
+- Cannot be used with `--additive_mask` (incompatible)
 
 ## Development
 


### PR DESCRIPTION
## Summary
- describe the configuration file parameters in the README for each section
- retain the recommendation for memory-efficient mode with documented trade-offs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e195a43fd0832babbb1376fd6eb1e7